### PR TITLE
Allow bgen-reader to work with files in read-only directories

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -8,8 +8,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [windows-latest] # ubuntu-latest, macos-latest]
-        python-version: [3.7] #, 3.8, 3.9]
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        python-version: [3.7, 3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v2
@@ -26,9 +26,9 @@ jobs:
 
     - name: Lint
       run: |
-        flake8 .
         black --check .
         isort --check-only .
+      # flake8 .
 
     - name: Test
       run: pytest .

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [windows-latest] # ubuntu-latest, macos-latest]
         python-version: [3.7] #, 3.8, 3.9]
 
     steps:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -26,7 +26,7 @@ jobs:
 
     - name: Lint
       run: |
-        flake8 .
+        flake8 . --verbose
         black --check .
         isort --check-only .
 

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -26,9 +26,9 @@ jobs:
 
     - name: Lint
       run: |
+        flake8 .
         black --check .
         isort --check-only .
-      # flake8 .
 
     - name: Test
       run: pytest .

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -26,7 +26,7 @@ jobs:
 
     - name: Lint
       run: |
-        flake8 . --verbose
+        flake8 .
         black --check .
         isort --check-only .
 

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -22,7 +22,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install flake8 pytest black isort setuptools --upgrade
-        pip install . --use-feature=in-tree-build && pip uninstall "$(python setup.py --name)" --yes
+        pip install . && pip uninstall "$(python setup.py --name)" --yes
 
     - name: Lint
       run: |

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.7] #, 3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v2

--- a/bgen_reader/_bgen2.py
+++ b/bgen_reader/_bgen2.py
@@ -126,6 +126,7 @@ class open_bgen:
         self,
         filepath: Union[str, Path],
         samples_filepath: Optional[Union[str, Path]] = None,
+        metadata_filepath: Optional[Union[str, Path]] = None,
         allow_complex: bool = False,
         verbose: bool = True,
     ):
@@ -139,12 +140,15 @@ class open_bgen:
             Path(samples_filepath) if samples_filepath is not None else None
         )
 
-        # Getting absolute paths is hard: https://discuss.python.org/t/pathlib-absolute-vs-resolve/2573/10
-        self._metadata2_path = self._metadata_path_from_filename(
-            self._filepath, self._samples_filepath, self._allow_complex
-        ).resolve()  # needed because of tmp_cwd in create_metadata
-        if not self._metadata2_path.is_absolute():
-            self._metadata2_path = Path.cwd() / self._metadata2_path
+        if metadata_filepath is None:
+            # Getting absolute paths is hard: https://discuss.python.org/t/pathlib-absolute-vs-resolve/2573/10
+            self._metadata2_path = self._metadata_path_from_filename(
+                self._filepath, self._samples_filepath, self._allow_complex
+            ).resolve()  # needed because of tmp_cwd in create_metadata
+            if not self._metadata2_path.is_absolute():
+                self._metadata2_path = Path.cwd() / self._metadata2_path
+        else:
+            self._metadata2_path = Path(metadata_filepath)
 
         self._cbgen = bgen_file(filepath)
 

--- a/bgen_reader/_bgen2.py
+++ b/bgen_reader/_bgen2.py
@@ -33,6 +33,10 @@ class open_bgen:
     samples_filepath
         Path to a `sample format`_ file or ``None`` to read samples from the BGEN file itself.
         Defaults to ``None``.
+    metadata_filepath
+        Tells where to be put the constructed metadata file. By default, will use the same
+        directory and name as the BGEN file, but with extension ``.metadata2.mmm``. Use this option,
+        for example, when the BGEN file's directory is read-only.
     allow_complex
         ``False`` (default) to assume homogeneous data; ``True`` to allow complex data.
         The BGEN format allows every variant to vary in its phaseness, its allele count,
@@ -49,7 +53,7 @@ class open_bgen:
 
     The first time a file is opened , ``open_bgen`` creates a .metadata2.mmm file, a process that takes seconds to hours,
     depending on the size of the file and the ``allow_complex`` setting. Subsequent openings take just a fraction of
-    a second. Changing ``samples_filepath`` or ``allow_complex`` results in a new .metadata2.mmm with a slightly
+    a second. Changing ``samples_filepath`` or ``allow_complex`` results in a new default .metadata2.mmm with a slightly
     different name.
 
     .. _open_examples:

--- a/bgen_reader/test/test_bgen2.py
+++ b/bgen_reader/test/test_bgen2.py
@@ -594,5 +594,27 @@ def test_threads():
                 assert val.shape == (row_count, col_count, 3)
 
 
+# def test_move_mmm():
+#     filepath = example_filepath("example.32bits.bgen")
+#     with open_bgen(
+#         filepath, metadata_filepath=r"m:\deldir\cmk.mmm", verbose=False
+#     ) as bgen2:
+#         for num_threads in [1, 2]:
+#             for slice in [np.s_[:, :], np.s_[:, []]]:
+#                 val = bgen2.read(index=slice, num_threads=num_threads)
+#                 row_count = len(bgen2.samples[slice[0]])
+#                 col_count = len(bgen2.ids[slice[1]])
+#                 assert val.shape == (row_count, col_count, 3)
+#     with open_bgen(
+#         filepath, metadata_filepath=r"m:\deldir\cmk.mmm", verbose=False
+#     ) as bgen2:
+#         for num_threads in [1, 2]:
+#             for slice in [np.s_[:, :], np.s_[:, []]]:
+#                 val = bgen2.read(index=slice, num_threads=num_threads)
+#                 row_count = len(bgen2.samples[slice[0]])
+#                 col_count = len(bgen2.ids[slice[1]])
+#                 assert val.shape == (row_count, col_count, 3)
+
+
 if __name__ == "__main__":
     pytest.main([__file__])

--- a/bgen_reader/test/test_bgen2.py
+++ b/bgen_reader/test/test_bgen2.py
@@ -594,26 +594,28 @@ def test_threads():
                 assert val.shape == (row_count, col_count, 3)
 
 
-# def test_move_mmm():
-#     filepath = example_filepath("example.32bits.bgen")
-#     with open_bgen(
-#         filepath, metadata_filepath=r"m:\deldir\cmk.mmm", verbose=False
-#     ) as bgen2:
-#         for num_threads in [1, 2]:
-#             for slice in [np.s_[:, :], np.s_[:, []]]:
-#                 val = bgen2.read(index=slice, num_threads=num_threads)
-#                 row_count = len(bgen2.samples[slice[0]])
-#                 col_count = len(bgen2.ids[slice[1]])
-#                 assert val.shape == (row_count, col_count, 3)
-#     with open_bgen(
-#         filepath, metadata_filepath=r"m:\deldir\cmk.mmm", verbose=False
-#     ) as bgen2:
-#         for num_threads in [1, 2]:
-#             for slice in [np.s_[:, :], np.s_[:, []]]:
-#                 val = bgen2.read(index=slice, num_threads=num_threads)
-#                 row_count = len(bgen2.samples[slice[0]])
-#                 col_count = len(bgen2.ids[slice[1]])
-#                 assert val.shape == (row_count, col_count, 3)
+def test_move_mmm(tmp_path):
+    filepath = example_filepath("example.32bits.bgen")
+    metadata_filepath = tmp_path / "metadata.other"
+    with open_bgen(
+        filepath, metadata_filepath=metadata_filepath, verbose=False
+    ) as bgen2:
+        for num_threads in [1, 2]:
+            for slice in [np.s_[:, :], np.s_[:, []]]:
+                val = bgen2.read(index=slice, num_threads=num_threads)
+                row_count = len(bgen2.samples[slice[0]])
+                col_count = len(bgen2.ids[slice[1]])
+                assert val.shape == (row_count, col_count, 3)
+    assert metadata_filepath.exists()
+    with open_bgen(
+        filepath, metadata_filepath=metadata_filepath, verbose=False
+    ) as bgen2:
+        for num_threads in [1, 2]:
+            for slice in [np.s_[:, :], np.s_[:, []]]:
+                val = bgen2.read(index=slice, num_threads=num_threads)
+                row_count = len(bgen2.samples[slice[0]])
+                col_count = len(bgen2.ids[slice[1]])
+                assert val.shape == (row_count, col_count, 3)
 
 
 if __name__ == "__main__":

--- a/bgen_reader/test/write_random.py
+++ b/bgen_reader/test/write_random.py
@@ -38,7 +38,7 @@ def _write_random(
     # https://web.archive.org/web/20181010160322/http://www.stats.ox.ac.uk/~marchini/software/gwas/file_format.html
     # We need the +1 so that all three values will have enough precision to be very near 1
     # The max(3,..) is needed to even 1 bit will have enough precision in the gen file
-    decimal_places = max(3, math.ceil(math.log(2 ** bits, 10)) + 1)
+    decimal_places = max(3, math.ceil(math.log(2**bits, 10)) + 1)
 
     def _format_function(num):
         return ("{0:." + str(decimal_places) + "f}").format(num)


### PR DESCRIPTION
This allows the user to put the metadata2 file in a different directory than the .bgen file.
It also addresses an update required by black.